### PR TITLE
Fix: Add explicit getters to EmailDetails due to Lombok @Data issues

### DIFF
--- a/src/main/java/com/example/demo/models/EmailDetails.java
+++ b/src/main/java/com/example/demo/models/EmailDetails.java
@@ -12,4 +12,11 @@ public class EmailDetails {
     private String msgBody;
     private String subject;
     private String attachment;
+
+    // #1st change request(setters & Getters)
+    public String getRecipient() { return recipient; }
+    public String getMsgBody() { return msgBody; }
+    public String getSubject() { return subject; }
+    public String getAttachment() { return attachment; }
+
 }


### PR DESCRIPTION
The EmailDetails class uses Lombok’s @Data annotation, which is supposed to auto-generate getters 
and setters at compile time. 
However, despite adding Lombok to the pom.xml, installing the IntelliJ Lombok plugin, and enabling 
annotation processing, the build fails with errors.

• Impact: 
This prevents the entire project from compiling, blocking all dependent features. 

• Planned Fix: 
Manually add explicit getRecipient(), getMsgBody(), getSubject(), and getAttachment() methods in the 
EmailDetails class to ensure the project builds correctly. 
This guarantees the system works even if Lombok annotation processing fails. 
